### PR TITLE
Auto author assign

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,15 @@
+name: Auto author assign
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assignAuthor:
+    name: Assign author to PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Assign author to PR
+        uses: technote-space/assign-author@v1
+


### PR DESCRIPTION
## Description
This is the first step of using github action in this repo. Hope that many useful workflows will be introduced soon.
This workflow simply assigns author to pr when the pr is created.